### PR TITLE
WindowsでもFileChooserのフィルタが効くように

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -141,7 +141,7 @@ void MainContentComponent::openButtonClicked()
 {
     FileChooser chooser("Select a audio file to play...",
                         File::nonexistent,
-                        "*.wav, *.wave, *.aif, *.aiff");
+                        "*.wav; *.wave; *.aif; *.aiff");
     if(chooser.browseForFileToOpen())
     {
         File file(chooser.getResult());


### PR DESCRIPTION
以下を参考にWindowsでもFileChooserのフィルタが効くようにしました
https://forum.juce.com/t/filechooser-and-filepatternsallowed/4460/7